### PR TITLE
fix the release build

### DIFF
--- a/Program.cs
+++ b/Program.cs
@@ -57,9 +57,9 @@ namespace ReClassNET
 			{
 				using (var nativeHelper = new CoreFunctionsManager())
 				{
-					mainForm = new MainForm(nativeHelper);
+					MainForm = new MainForm(nativeHelper);
 
-					Application.Run(mainForm);
+					Application.Run(MainForm);
 				}
 			}
 			catch (Exception ex)


### PR DESCRIPTION
Hi there!

In the release build, `Program.cs` refers to an incorrectly cased `mainForm`. This pull request just fixes that small typo.