### PR TITLE
fixed distorm compilation on linux

### DIFF
--- a/NativeCore/Shared/DistormHelper.cpp
+++ b/NativeCore/Shared/DistormHelper.cpp
@@ -1,6 +1,7 @@
 #include "DistormHelper.hpp"
 
 #include <distorm.h>
+#include <mnemonics.h>
 extern "C"
 {
 #include <../src/instructions.h>

--- a/NativeCore/Unix/Makefile
+++ b/NativeCore/Unix/Makefile
@@ -1,13 +1,13 @@
 WORKDIR = `pwd`
 
 CC = gcc
-CXX = g++
+CXX = gcc
 AR = ar
 LD = g++
 WINDRES = windres
 
 INC = -I../Dependencies/distorm/include
-CFLAGS = -Wall -fPIC -D RECLASSNET64=1
+CFLAGS = -Wall -fPIC -fpermissive -DRECLASSNET64=1
 RESINC =
 LIBDIR =
 LIB = -lstdc++fs


### PR DESCRIPTION
didnt compile out of the box on g++ for me so i switched to gcc and added the missing header file