### PR TITLE
Cosmetic changes for "About" dialog

### DIFF
--- a/ReClass.NET/Forms/AboutForm.Designer.cs
+++ b/ReClass.NET/Forms/AboutForm.Designer.cs
@@ -175,6 +175,9 @@
 			this.Controls.Add(this.platformLabel);
 			this.Controls.Add(this.infoLabel);
 			this.Controls.Add(this.bannerBox);
+			this.FormBorderStyle = System.Windows.Forms.FormBorderStyle.FixedDialog;
+			this.MaximizeBox = false;
+			this.MinimizeBox = false;
 			this.Name = "AboutForm";
 			this.StartPosition = System.Windows.Forms.FormStartPosition.CenterParent;
 			this.Text = "ReClass.NET - Info";


### PR DESCRIPTION
Before the commit the "About" dialog was resizable(it probably shouldn't be)

That's how it looks after maximize/resize:
![reclass net_2018-01-14_16-17-02](https://user-images.githubusercontent.com/11231925/34917710-527117f2-f94a-11e7-9c0d-0b1b08ec5a5f.png)
![reclass net_2018-01-14_16-16-38](https://user-images.githubusercontent.com/11231925/34917712-57989da4-f94a-11e7-91c7-211ea4e1b961.png)

This commit blocks the possibility to resize the window.
