### PR TITLE
Fix crash when using "Insert Bytes" on the topmost entry

### DIFF
--- a/ReClass.NET/Forms/MainForm.cs
+++ b/ReClass.NET/Forms/MainForm.cs
@@ -495,7 +495,7 @@ namespace ReClassNET.Forms
 			};
 
 			addBytesToolStripMenuItem.Enabled = parentNode != null || nodeIsClass;
-			insertBytesToolStripMenuItem.Enabled = count == 1 && parentNode != null;
+			insertBytesToolStripMenuItem.Enabled = count == 1 && parentNode != null && !nodeIsClass;
 
 			changeTypeToolStripMenuItem.Enabled = count > 0 && !nodeIsClass;
 
@@ -829,11 +829,12 @@ namespace ReClassNET.Forms
 
 			var node = selectedNodes.FirstOrDefault()?.Node;
 			var parentContainer = node?.GetParentContainer();
+			var nodeIsClass = node is ClassNode;
 
-			addBytesToolStripDropDownButton.Enabled = parentContainer != null || node is ClassNode;
-			insertBytesToolStripDropDownButton.Enabled = selectedNodes.Count == 1 && parentContainer != null;
+			addBytesToolStripDropDownButton.Enabled = parentContainer != null || nodeIsClass;
+			insertBytesToolStripDropDownButton.Enabled = selectedNodes.Count == 1 && parentContainer != null && !nodeIsClass;
 
-			var enabled = selectedNodes.Count > 0 && !(node is ClassNode);
+			var enabled = selectedNodes.Count > 0 && !nodeIsClass;
 			toolStrip.Items.OfType<TypeToolStripButton>().ForEach(b => b.Enabled = enabled);
 		}
 

--- a/ReClass.NET/Nodes/BaseContainerNode.cs
+++ b/ReClass.NET/Nodes/BaseContainerNode.cs
@@ -243,9 +243,8 @@ namespace ReClassNET.Nodes
 
 		public void InsertBytes(BaseNode position, int size)
 		{
-			int index = FindNodeIndex(position);
 			List<BaseNode> dummy = null;
-			InsertBytes(index >= 0 ? index : 0, size, ref dummy);
+			InsertBytes(FindNodeIndex(position), size, ref dummy);
 		}
 
 		/// <summary>Inserts <paramref name="size"/> bytes at the specified position.</summary>


### PR DESCRIPTION
When using the "Insert Bytes" functions after right-clicking on the top-most class ReClass will crash with an ArgumentException due to the starting index being set to -1.

![image](https://user-images.githubusercontent.com/1786181/136530171-b1f70eef-8061-4a2f-b458-a6fb4065d5ef.png)

This PR will fix the function and insert the Bytes at position 0 (which is kind of the expected behavior).
Alternatively, the "Insert Bytes" menu entries could also be entirely removed when right-clicking on the class.