### PR TITLE
github action to build latest master push

### DIFF
--- a/.github/workflows/master-build.yaml
+++ b/.github/workflows/master-build.yaml
@@ -23,7 +23,7 @@ jobs:
       run: echo "::set-output name=sha_short::$(git rev-parse --short HEAD)"
     - name: MSBuild
       run: |
-        Remove-Item -R -Fo bin
+        Remove-Item -R -Fo -EA SilentlyContinue bin
         msbuild /t:Reclass_NET:Rebuild /p:Configuration=Release /p:Platform=x64 ReClass.NET.sln
         msbuild /t:Reclass_NET:Rebuild /p:Configuration=Release /p:Platform=x86 ReClass.NET.sln
     - name: Zip release

--- a/.github/workflows/master-build.yaml
+++ b/.github/workflows/master-build.yaml
@@ -1,0 +1,42 @@
+###
+# Automatically build a "Development Build" on a push to master.
+##
+
+name: Master Build
+
+on:
+  workflow_dispatch:
+  push:
+    branches:
+      - master
+
+jobs:
+  build:
+    runs-on: windows-latest
+    steps:
+    - name: Setup MSBuild.exe
+      uses: microsoft/setup-msbuild@v1.0.2
+    - name: Checkout
+      uses: actions/checkout@v2.4.0
+    - name: Set outputs
+      id: vars
+      run: echo "::set-output name=sha_short::$(git rev-parse --short HEAD)"
+    - name: MSBuild
+      run: |
+        Remove-Item -R -Fo bin
+        msbuild /t:Reclass_NET:Rebuild /p:Configuration=Release /p:Platform=x64 ReClass.NET.sln
+        msbuild /t:Reclass_NET:Rebuild /p:Configuration=Release /p:Platform=x86 ReClass.NET.sln
+    - name: Zip release
+      uses: papeloto/action-zip@v1
+      with:
+        files: bin\Release
+        recursive: true
+        dest: ReClass.NET-${{ steps.vars.outputs.sha_short }}.zip
+    - name: Release
+      uses: marvinpinto/action-automatic-releases@v1.2.1
+      with:
+        repo_token: "${{ secrets.GITHUB_TOKEN }}"
+        automatic_release_tag: "latest"
+        prerelease: true
+        title: "Development Build"
+        files: ReClass.NET-${{ steps.vars.outputs.sha_short }}.zip


### PR DESCRIPTION
On a push to master it will build a developmental build and add the archive under releases, allowing people to use the latest features w/o having to clone the repo and build it themselves. 

Example:
![image](https://user-images.githubusercontent.com/1458109/172418184-57d7ea11-9432-4c32-9c00-85f9aa0371aa.png)
