### PR TITLE
Fix infinite loop in iteration of memory mapping lines

### DIFF
--- a/NativeCore/Unix/EnumerateRemoteSectionsAndModules.cpp
+++ b/NativeCore/Unix/EnumerateRemoteSectionsAndModules.cpp
@@ -52,11 +52,12 @@ extern "C" void RC_CallConv EnumerateRemoteSectionsAndModules(RC_Pointer handle,
 
 	auto path = std::stringstream();
 	path << "/proc/" << reinterpret_cast<intptr_t>(handle) << "/maps";
+	std::ifstream input(path.str());
 
 	std::unordered_map<int, ModuleInfo> modules;
 
 	std::string line;
-	while (std::getline(std::ifstream(path.str()), line))
+	while (std::getline(input, line))
 	{
 		std::stringstream ss(line);
 


### PR DESCRIPTION
This fixes #242.

Iteration of the file's lines was broken in e1289162.