### PR TITLE
Implement more sane caret behavior

### DIFF
--- a/ReClass.NET/Controls/HotSpotTextBox.cs
+++ b/ReClass.NET/Controls/HotSpotTextBox.cs
@@ -1,7 +1,9 @@
 using System;
 using System.ComponentModel;
 using System.Drawing;
+using System.Linq;
 using System.Windows.Forms;
+using ReClassNET.Debugger;
 using ReClassNET.UI;
 
 namespace ReClassNET.Controls
@@ -54,6 +56,85 @@ namespace ReClassNET.Controls
 			}
 		}
 
+		protected override bool ProcessCmdKey(ref Message m, Keys keyData)
+		{
+			bool state = base.ProcessCmdKey(ref m, keyData);
+
+			// Checks if we're on some address.
+			var selectionPredicate = (char c) =>
+			{
+				c = Char.ToLower(c);
+				return (c >= '0' && c <= '9') || (c >= 'a' && c <= 'f') || c == 'x';
+			};
+
+			if (keyData == (Keys.Control | Keys.Left))
+			{
+				if (SelectionStart > 0 && !string.IsNullOrEmpty(Text))
+				{
+					var atEnd = SelectionStart == Text.Length;
+					var selectionInText = Math.Min(SelectionStart, Text.Length - 1);
+					var currChar = () => Text[selectionInText - 1];
+					bool currMatchesPredicate = (atEnd && selectionPredicate(Text[selectionInText])) || selectionPredicate(currChar());
+
+					if (currMatchesPredicate)
+					{
+						while (selectionInText > 0 && selectionPredicate(currChar()))
+						{
+							selectionInText -= 1;
+						}
+					}
+					else
+					{
+						selectionInText -= 1;
+						while (selectionInText > 0 && !selectionPredicate(currChar()))
+						{
+							selectionInText -= 1;
+						}
+					}
+
+					selectionInText = Math.Max(selectionInText, 0);
+					SelectionStart = selectionInText;
+					SelectionLength = 0;
+
+					return true;
+				}
+			}
+			else if (keyData == (Keys.Control | Keys.Right))
+			{
+				var maxSelectionStart = Text.Length;
+				if (!string.IsNullOrEmpty(Text) && SelectionStart != maxSelectionStart)
+				{
+					var selectionInText = Math.Min(SelectionStart, Text.Length - 1);
+					var currChar = () => Text[selectionInText];
+					bool currMatchesPredicate = selectionPredicate(currChar());
+
+					if (currMatchesPredicate)
+					{
+						while (selectionInText < maxSelectionStart && selectionPredicate(currChar()))
+						{
+							selectionInText += 1;
+						}
+					}
+					else
+					{
+						selectionInText += 1;
+						while (selectionInText > 0 && !selectionPredicate(currChar()))
+						{
+							selectionInText += 1;
+						}
+					}
+
+					selectionInText = Math.Min(selectionInText, maxSelectionStart);
+					SelectionStart = selectionInText;
+					SelectionLength = 0;
+
+					return true;
+				}
+			}
+
+			return state;
+		}
+
 		protected override void OnKeyDown(KeyEventArgs e)
 		{
 			if (e.KeyCode == Keys.Enter)
@@ -87,7 +168,7 @@ namespace ReClassNET.Controls
 			Committed?.Invoke(this, new HotSpotTextBoxCommitEventArgs(currentHotSpot));
 		}
 
-		#endregion
+		#endregion Events
 
 		public void ShowOnHotSpot(HotSpot hotSpot)
 		{

--- a/ReClass.NET/Controls/HotSpotTextBox.cs
+++ b/ReClass.NET/Controls/HotSpotTextBox.cs
@@ -62,7 +62,7 @@ namespace ReClassNET.Controls
 			var selectionPredicate = (char c) =>
 			{
 				c = Char.ToLower(c);
-				return (c >= '0' && c <= '9') || (c >= 'a' && c <= 'f') || c == 'x';
+				return (c >= '0' && c <= '9') || (c >= 'a' && c <= 'z');
 			};
 
 			if (keyData == (Keys.Control | Keys.Left))

--- a/ReClass.NET/Controls/HotSpotTextBox.cs
+++ b/ReClass.NET/Controls/HotSpotTextBox.cs
@@ -58,8 +58,6 @@ namespace ReClassNET.Controls
 
 		protected override bool ProcessCmdKey(ref Message m, Keys keyData)
 		{
-			bool state = base.ProcessCmdKey(ref m, keyData);
-
 			// Checks if we're on some address.
 			var selectionPredicate = (char c) =>
 			{
@@ -132,7 +130,7 @@ namespace ReClassNET.Controls
 				}
 			}
 
-			return state;
+			return base.ProcessCmdKey(ref m, keyData);
 		}
 
 		protected override void OnKeyDown(KeyEventArgs e)

--- a/ReClass.NET/Controls/HotSpotTextBox.cs
+++ b/ReClass.NET/Controls/HotSpotTextBox.cs
@@ -118,7 +118,7 @@ namespace ReClassNET.Controls
 					else
 					{
 						selectionInText += 1;
-						while (selectionInText > 0 && !selectionPredicate(currChar()))
+						while (selectionInText < maxSelectionStart && !selectionPredicate(currChar()))
 						{
 							selectionInText += 1;
 						}


### PR DESCRIPTION
This implements a more sane behavior for caret movements, particularly for the Ctrl+Left/Ctrl+Right commands. This is somewhat similar to Notepad's, but better.

If you're hovering over a character that can be part of an address, we will progress one way or the other with the caret, until there's a character that's not part of the aforementioned predicate. The exception are the start or end of the textbox.

This is useful to quickly go over arithmetic, remove '`' from addresses that you get from WinDbg, etc.

It would probably be good to also implement Ctrl+Shift variation for Left+Right, and Ctrl+Backspace. I'm willing to do it if that's wanted (I may anyway, eventually).