### PR TITLE
Allow loading of uncompressed rcnet file to allow version control tools to work nicely w/ ReClass.NET files

### DIFF
--- a/ReClass.NET/DataExchange/ReClass/ReClassNetFile.Constants.cs
+++ b/ReClass.NET/DataExchange/ReClass/ReClassNetFile.Constants.cs
@@ -3,8 +3,11 @@
 	public partial class ReClassNetFile
 	{
 		public const string FormatName = "ReClass.NET File";
-		public const string FileExtension = ".rcnet";
+		public const string DefaultFileExtension = ".rcnet";
+		public const string AlternateFormatName = "ReClass.NET XML File";
+		public const string AlternateFileExtension = ".rcnetxml";
 		public const string FileExtensionId = "rcnetfile";
+		public const string AlternateFileExtensionId = "rcnetxmlfile";
 
 		private const uint FileVersion = 0x00010001;
 		private const uint FileVersionCriticalMask = 0xFFFF0000;

--- a/ReClass.NET/DataExchange/ReClass/ReClassNetFile.Write.cs
+++ b/ReClass.NET/DataExchange/ReClass/ReClassNetFile.Write.cs
@@ -17,16 +17,23 @@ namespace ReClassNET.DataExchange.ReClass
 		{
 			using var fs = new FileStream(filePath, FileMode.Create);
 
-			Save(fs, logger);
+			var ext = Path.GetExtension(filePath);
+			if(ext == DefaultFileExtension)
+			{
+				using var archive = new ZipArchive(fs, ZipArchiveMode.Create);
+
+				var dataEntry = archive.CreateEntry(DataFileName);
+				using var entryStream = dataEntry.Open();
+				Save(entryStream, logger);
+			} 
+			else if(ext == AlternateFileExtension)
+			{
+				Save(fs, logger);
+			}
 		}
 
 		public void Save(Stream output, ILogger logger)
 		{
-			using var archive = new ZipArchive(output, ZipArchiveMode.Create);
-
-			var dataEntry = archive.CreateEntry(DataFileName);
-			using var entryStream = dataEntry.Open();
-
 			var document = new XDocument(
 				new XComment($"{Constants.ApplicationName} {Constants.ApplicationVersion} by {Constants.Author}"),
 				new XComment($"Website: {Constants.HomepageUrl}"),
@@ -41,7 +48,7 @@ namespace ReClassNET.DataExchange.ReClass
 				)
 			);
 
-			document.Save(entryStream);
+			document.Save(output);
 		}
 
 		private static IEnumerable<XElement> CreateEnumElements(IEnumerable<EnumDescription> enums)

--- a/ReClass.NET/Forms/MainForm.Functions.cs
+++ b/ReClass.NET/Forms/MainForm.Functions.cs
@@ -193,8 +193,9 @@ namespace ReClassNET.Forms
 			using var ofd = new OpenFileDialog
 			{
 				CheckFileExists = true,
-				Filter = $"All ReClass Types |*{ReClassNetFile.FileExtension};*{ReClassFile.FileExtension};*{ReClassQtFile.FileExtension}"
-				         + $"|{ReClassNetFile.FormatName} (*{ReClassNetFile.FileExtension})|*{ReClassNetFile.FileExtension}"
+				Filter = $"All ReClass Types |*{ReClassNetFile.DefaultFileExtension};*{ReClassNetFile.AlternateFileExtension};*{ReClassFile.FileExtension};*{ReClassQtFile.FileExtension}"
+				         + $"|{ReClassNetFile.FormatName} (*{ReClassNetFile.DefaultFileExtension})|*{ReClassNetFile.DefaultFileExtension}"
+				         + $"|{ReClassNetFile.AlternateFormatName} (*{ReClassNetFile.AlternateFileExtension})|*{ReClassNetFile.AlternateFileExtension}"
 				         + $"|{ReClassFile.FormatName} (*{ReClassFile.FileExtension})|*{ReClassFile.FileExtension}"
 				         + $"|{ReClassQtFile.FormatName} (*{ReClassQtFile.FileExtension})|*{ReClassQtFile.FileExtension}"
 			};
@@ -218,7 +219,9 @@ namespace ReClassNET.Forms
 			LoadProjectFromPath(path, ref project);
 
 			// If the file is a ReClass.NET file remember the path.
-			if (Path.GetExtension(path) == ReClassNetFile.FileExtension)
+			var ext = Path.GetExtension(path);
+			if (ext == ReClassNetFile.DefaultFileExtension
+				|| ext == ReClassNetFile.AlternateFileExtension)
 			{
 				project.Path = path;
 			}
@@ -238,7 +241,8 @@ namespace ReClassNET.Forms
 			IReClassImport import;
 			switch (Path.GetExtension(path)?.ToLower())
 			{
-				case ReClassNetFile.FileExtension:
+				case ReClassNetFile.DefaultFileExtension:
+				case ReClassNetFile.AlternateFileExtension:
 					import = new ReClassNetFile(project);
 					break;
 				case ReClassQtFile.FileExtension:

--- a/ReClass.NET/Forms/MainForm.cs
+++ b/ReClass.NET/Forms/MainForm.cs
@@ -307,8 +307,9 @@ namespace ReClassNET.Forms
 
 			using var sfd = new SaveFileDialog
 			{
-				DefaultExt = ReClassNetFile.FileExtension,
-				Filter = $"{ReClassNetFile.FormatName} (*{ReClassNetFile.FileExtension})|*{ReClassNetFile.FileExtension}"
+				DefaultExt = ReClassNetFile.DefaultFileExtension,
+				Filter = $"{ReClassNetFile.FormatName} (*{ReClassNetFile.DefaultFileExtension})|*{ReClassNetFile.DefaultFileExtension}"
+						+ $"|{ReClassNetFile.AlternateFormatName} (*{ReClassNetFile.AlternateFileExtension})|*{ReClassNetFile.AlternateFileExtension}"
 			};
 
 			if (sfd.ShowDialog() == DialogResult.OK)
@@ -756,7 +757,8 @@ namespace ReClassNET.Forms
 				{
 					switch (Path.GetExtension(files.First()))
 					{
-						case ReClassNetFile.FileExtension:
+						case ReClassNetFile.DefaultFileExtension:
+						case ReClassNetFile.AlternateFileExtension:
 						case ReClassQtFile.FileExtension:
 						case ReClassFile.FileExtension:
 							e.Effect = DragDropEffects.Copy;

--- a/ReClass.NET_Launcher/Program.cs
+++ b/ReClass.NET_Launcher/Program.cs
@@ -19,13 +19,15 @@ namespace ReClassNET_Launcher
 			// Register the files with the launcher.
 			if (commandLineArgs[Constants.CommandLineOptions.FileExtRegister] != null)
 			{
-				NativeMethods.RegisterExtension(ReClassNetFile.FileExtension, ReClassNetFile.FileExtensionId, PathUtil.ExecutablePath, Constants.ApplicationName);
+				NativeMethods.RegisterExtension(ReClassNetFile.DefaultFileExtension, ReClassNetFile.FileExtensionId, PathUtil.ExecutablePath, Constants.ApplicationName);
+				NativeMethods.RegisterExtension(ReClassNetFile.AlternateFileExtension, ReClassNetFile.AlternateFileExtensionId, PathUtil.ExecutablePath, Constants.ApplicationName);
 
 				return;
 			}
 			if (commandLineArgs[Constants.CommandLineOptions.FileExtUnregister] != null)
 			{
-				NativeMethods.UnregisterExtension(ReClassNetFile.FileExtension, ReClassNetFile.FileExtensionId);
+				NativeMethods.UnregisterExtension(ReClassNetFile.DefaultFileExtension, ReClassNetFile.FileExtensionId);
+				NativeMethods.UnregisterExtension(ReClassNetFile.AlternateFileExtension, ReClassNetFile.AlternateFileExtensionId);
 
 				return;
 			}


### PR DESCRIPTION
Redo of #227 cleaned up w/o the unnecessary changes git added.

When working on rcnet files w/ multiple people, right now it is impossible to see changes from version to version since they are a zip archive. This PR is an attempt at allowing a `rcnetxml` to be Saved/Loaded with the raw XML to allow version tracking tools like git to work nicely w/ the files.